### PR TITLE
Fix errors and deprecations with more recent D versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,22 @@
+name: tests
+on: [pull_request, push, release]
+
+jobs:
+  tests:
+    name: Unittests
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-latest]
+        dc: [dmd-2.075.1, dmd-latest, ldc-1.5.0, ldc-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up D toolchain
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ matrix.dc }}
+
+      - name: Run unittests
+        run: dub test --build=unittest-cov

--- a/src/dxorshift/xoroshiro128plus.d
+++ b/src/dxorshift/xoroshiro128plus.d
@@ -116,15 +116,14 @@ struct Xoroshiro128plus
     void jump() @nogc @safe nothrow pure
     {
         enum ulong[2] jump_ = [0xbeac0467eba5facb, 0xd86b048b86aa9922];
-        enum jumpSize = jump_.sizeof / (*(jump_.ptr)).sizeof;
         ulong s0 = 0;
         ulong s1 = 0;
 
-        for (size_t i = 0; i < jumpSize; ++i)
+        foreach (jmp; jump_)
         {
             for (int b = 0; b < 64; ++b)
             {
-                if (jump_[i] & 1uL << b)
+                if (jmp & 1uL << b)
                 {
                     s0 ^= this.state[0];
                     s1 ^= this.state[1];
@@ -149,7 +148,7 @@ struct Xoroshiro128plus
      */
     typeof(this) dup() @nogc @property @safe nothrow pure
     {
-        return typeof(this)(this);
+        return typeof(this)(&this);
     }
 
     /// (Re)seeds the generator.
@@ -204,7 +203,7 @@ struct Xoroshiro128plus
     ulong[2] state;
 
     // Helper constructor used to implement `dup`
-    this(ref typeof(this) that) @nogc @safe nothrow pure
+    this(const(typeof(this)*) that) @nogc @safe nothrow pure
     {
         this.state[] = that.state[];
     }
@@ -279,7 +278,7 @@ unittest
     static assert(isSeedable!(Xoroshiro128plus, ulong[2]));
     static assert(isSeedable!(Xoroshiro128plus, ulong[]));
     static assert(isSeedable!(Xoroshiro128plus, ulong));
-    static assert(isSeedable!(Xoroshiro128plus, SplitMix64));
+    static assert(isSeedable!(Xoroshiro128plus, SplitMix64*));
 
     // output comparisons to reference implementation,
     // using constructor, seeding, and duplication

--- a/src/dxorshift/xoroshiro128plus.d
+++ b/src/dxorshift/xoroshiro128plus.d
@@ -100,7 +100,7 @@ struct Xoroshiro128plus
     {
         assert(this.state != [0uL, 0uL]);
     }
-    body
+    do
     {
         immutable ulong s1 = this.state[1] ^ this.state[0];
         this.state[0] = rotateLeft(this.state[0], 55) ^ s1 ^ (s1 << 14);
@@ -165,7 +165,7 @@ struct Xoroshiro128plus
         // seeds are not both 0
         assert(!(!s0 && !s1));
     }
-    body
+    do
     {
         this.state[0] = s0;
         this.state[1] = s1;
@@ -178,7 +178,7 @@ struct Xoroshiro128plus
     {
         assert(!(!s[0] && !s[1]));
     }
-    body
+    do
     {
         seed(s[0], s[1]);
     }
@@ -215,7 +215,7 @@ struct Xoroshiro128plus
         assert(0 <= k);
         assert(k <= 64);
     }
-    body
+    do
     {
         return (x << k) | (x >> (64 - k));
     }

--- a/src/dxorshift/xorshift1024star.d
+++ b/src/dxorshift/xorshift1024star.d
@@ -96,7 +96,7 @@ public struct Xorshift1024star
     {
         assert(this.state != typeof(this.state).init);
     }
-    body
+    do
     {
         immutable ulong s0 = this.state[this.p];
         ulong s1 = this.state[this.p = (this.p + 1) & 15];
@@ -171,7 +171,7 @@ public struct Xorshift1024star
     {
         assert(s != typeof(s).init);
     }
-    body
+    do
     {
         this.state[] = s[];
         this.p = 0;

--- a/src/dxorshift/xorshift1024star.d
+++ b/src/dxorshift/xorshift1024star.d
@@ -117,28 +117,27 @@ public struct Xorshift1024star
              0x2ffeeb0a48316f40, 0xdc2d9891fe68c022, 0x3659132bb12fea70, 0xaac17d8efa43cab8,
              0xc4cb815590989b13, 0x5ee975283d71c93b, 0x691548c86c1bd540, 0x7910c41d10a1e6a5,
              0x0b5fc64563b3e2a8, 0x047f7684e9fc949d, 0xb99181f2d8f685ca, 0x284600e3f30e38c3];
-        enum jumpSize = jump_.sizeof / (*(jump_.ptr)).sizeof;
 
         ulong[16] t;
 
-        foreach (immutable size_t i; 0 .. jumpSize)
+        foreach (jmp; jump_)
         {
             foreach (immutable int b; 0 .. 64)
             {
-                if (jump_[i] & 1uL << b)
+                if (jmp & 1uL << b)
                 {
-                    foreach (immutable int j; 0 .. 16)
+                    foreach (immutable int i; 0 .. 16)
                     {
-                        t[j] ^= this.state[(j + this.p) & 15];
+                        t[i] ^= this.state[(i + this.p) & 15];
                     }
                 }
                 this.popFront();
             }
         }
 
-        foreach (immutable int j; 0 .. 16)
+        foreach (immutable int i; 0 .. 16)
         {
-            this.state[(j + this.p) & 15] = t[j];
+            this.state[(i + this.p) & 15] = t[i];
         }
 
         this.popFront();
@@ -156,7 +155,7 @@ public struct Xorshift1024star
      */
     typeof(this) dup() @nogc @property @safe nothrow pure
     {
-        return typeof(this)(this);
+        return typeof(this)(&this);
     }
 
     /// (Re)seeds the generator.
@@ -203,7 +202,7 @@ public struct Xorshift1024star
     int p;
 
     // Helper constructor used to implement `dup`
-    this(ref typeof(this) that) @nogc @safe nothrow pure
+    this(const(typeof(this)*) that) @nogc @safe nothrow pure
     {
         this.state[] = that.state[];
         this.p = that.p;
@@ -263,7 +262,7 @@ unittest
     static assert(isUniformRNG!Xorshift1024star);
     static assert(isSeedable!Xorshift1024star);
     static assert(isSeedable!(Xorshift1024star, ulong[16]));
-    static assert(isSeedable!(Xorshift1024star, SplitMix64));
+    static assert(isSeedable!(Xorshift1024star, SplitMix64*));
 
     // output comparisons to reference implementation,
     // using constructor, seeding, and duplication


### PR DESCRIPTION
Since `dxorshift` was first released, a number of details of the code are now either deprecated or treated as outright errors.  The first patch in this PR fixes the errors that prevent compilation, while the second replaces deprecated code with the preferred alternative.